### PR TITLE
Support for writing single element arrays as json arrays (3/3)

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder/api/RepresentationFactory.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/api/RepresentationFactory.java
@@ -14,6 +14,8 @@ public abstract class RepresentationFactory {
     public static final URI COALESCE_LINKS = makeUri("urn:halbuilder:coalescelinks");
 
     public static final URI STRIP_NULLS = makeUri("urn:halbuilder:stripnulls");
+    
+    public static final URI SINGLE_ELEM_ARRAYS = makeUri("urn:halbuild:singleelemarrays");
 
     protected static URI makeUri(String uri) {
         try {


### PR DESCRIPTION
There are three total pull requests as three separate repos are affected, all contain the same description below.

Adds support for serializing single element arrays as json arrays rather than unwrapping them into values.  This is something I have run into frequently, particularly when interfacing with services written in other languages.

This is a fairly simple change implemented similarly to STRIP_NULLS, a new flag was added to RepresentationFactory, SINGLE_ELEM_ARRAYS that when set will serialize collections containing a single element as a json array rather than a value using the WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED serialization feature in jackson.

New tests were added to halbuilder-json to test serializing single element arrays with and without SINGLE_ELEM_ARRAYS.   New example files were added to halbuilder-test-resources to support the tests.
