### PR TITLE
Add constant for hypertext cache pattern.

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder/api/RepresentationFactory.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/api/RepresentationFactory.java
@@ -9,21 +9,15 @@ public abstract class RepresentationFactory {
     public static final String HAL_XML = "application/hal+xml";
     public static final String HAL_JSON = "application/hal+json";
 
-    public static final URI PRETTY_PRINT = makeUri("urn:halbuilder:prettyprint");
+    public static final URI PRETTY_PRINT = URI.create("urn:halbuilder:prettyprint");
 
-    public static final URI COALESCE_LINKS = makeUri("urn:halbuilder:coalescelinks");
+    public static final URI COALESCE_LINKS = URI.create("urn:halbuilder:coalescelinks");
 
-    public static final URI STRIP_NULLS = makeUri("urn:halbuilder:stripnulls");
+    public static final URI STRIP_NULLS = URI.create("urn:halbuilder:stripnulls");
     
-    public static final URI SINGLE_ELEM_ARRAYS = makeUri("urn:halbuild:singleelemarrays");
+    public static final URI SINGLE_ELEM_ARRAYS = URI.create("urn:halbuild:singleelemarrays");
 
-    protected static URI makeUri(String uri) {
-        try {
-            return new URI(uri);
-        } catch (URISyntaxException e) {
-            throw new RepresentationException(e);
-        }
-    }
+    public static final URI HYPERTEXT_CACHE_PATTERN = URI.create("urn:halbuild:hypertextcachepattern");
 
     public abstract RepresentationFactory withNamespace(String namespace, String href);
 


### PR DESCRIPTION
See https://tools.ietf.org/html/draft-kelly-json-hal-06#section-8.3

While I was there, I removed the `makeUri` call, since this seems superfluous compared to using `URI.create`. makeUri was marked protected, so this is technically an API break. Happy to remove that part of this if requested.
